### PR TITLE
#172 카카오톡 링크 추출 시 메타데이터도 추가로 추출하기

### DIFF
--- a/linknamu/src/main/java/com/kakao/linknamu/kakao/dto/KakaoSendMeResponseDto.java
+++ b/linknamu/src/main/java/com/kakao/linknamu/kakao/dto/KakaoSendMeResponseDto.java
@@ -1,6 +1,7 @@
 package com.kakao.linknamu.kakao.dto;
 
 public record KakaoSendMeResponseDto(
+		String title,
         String link
 
 ) {

--- a/linknamu/src/main/java/com/kakao/linknamu/kakao/service/KaKaoSendMeExtractService.java
+++ b/linknamu/src/main/java/com/kakao/linknamu/kakao/service/KaKaoSendMeExtractService.java
@@ -25,7 +25,7 @@ import lombok.RequiredArgsConstructor;
 public class KaKaoSendMeExtractService {
 
 	private final JsoupUtils jsoupUtils;
-	private static final String DEFAULT_TITLE = "북마크 링크";
+	private static final String DEFAULT_TITLE = "추출된 링크";
 
 	public List<KakaoSendMeResponseDto> extractLink(MultipartFile multipartFile) {
 

--- a/linknamu/src/main/java/com/kakao/linknamu/kakao/service/KaKaoSendMeExtractService.java
+++ b/linknamu/src/main/java/com/kakao/linknamu/kakao/service/KaKaoSendMeExtractService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.kakao.linknamu.thirdparty.utils.JsoupUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -22,6 +23,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Service
 public class KaKaoSendMeExtractService {
+
+	private final JsoupUtils jsoupUtils;
+	private static final String DEFAULT_TITLE = "북마크 링크";
 
 	public List<KakaoSendMeResponseDto> extractLink(MultipartFile multipartFile) {
 
@@ -47,10 +51,31 @@ public class KaKaoSendMeExtractService {
 			//        \bhttps?://\S+   => 모든 http, https 도메인 검출
 			Pattern pattern = Pattern.compile(regex);
 			Matcher matcher = pattern.matcher(fileContent);
-			while (matcher.find()) {
-				String httpsLink = matcher.group();
-				responseDtos.add(new KakaoSendMeResponseDto(httpsLink));
-			}
+
+			// 병렬 쓰레드로 실행
+			matcher.results().parallel()
+				.forEach(matchResult -> {
+					String httpsLink = matchResult.group();
+					if(httpsLink.endsWith("\""))
+						httpsLink = httpsLink.substring(0, httpsLink.length()-1);
+					String title = jsoupUtils.getTitle(httpsLink);
+					responseDtos.add(new KakaoSendMeResponseDto(
+						title.equals(httpsLink) ? DEFAULT_TITLE : title,
+						httpsLink)
+					);
+				});
+
+//			while (matcher.find()) {
+//				String httpsLink = matcher.group();
+//				if(httpsLink.endsWith("\""))
+//					httpsLink = httpsLink.substring(0, httpsLink.length()-1);
+//
+//				String title = jsoupUtils.getTitle(httpsLink);
+//				responseDtos.add(new KakaoSendMeResponseDto(
+//					title.equals(httpsLink) ? DEFAULT_TITLE : title,
+//					httpsLink)
+//				);
+//			}
 			return responseDtos;
 		} catch (IOException e) {
 			throw new Exception500(KakaoExceptionStatus.FILE_READ_FAILED);

--- a/linknamu/src/main/java/com/kakao/linknamu/thirdparty/utils/JsoupUtils.java
+++ b/linknamu/src/main/java/com/kakao/linknamu/thirdparty/utils/JsoupUtils.java
@@ -4,11 +4,12 @@ import lombok.RequiredArgsConstructor;
 import org.jsoup.Connection;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.util.Objects;
 
 
 @Component
@@ -18,18 +19,27 @@ public class JsoupUtils {
     @Value("${proxy.enabled:false}")
     private boolean isProxyEnabled;
 
-    private final static String PROXY_HOST = "krmp-proxy.9rum.cc";
-    private final static int PROXY_PORT = 3128;
+    private static final String PROXY_HOST = "krmp-proxy.9rum.cc";
+    private static final int PROXY_PORT = 3128;
+	private static final String USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 Safari/537.36";
 
     public String getTitle(String href) {
         try{
             Connection connection = Jsoup.connect(href)
-                    .timeout(5000);
+				.userAgent(USER_AGENT)
+				.timeout(5000);
 
             if(isProxyEnabled) {
                 connection = connection.proxy(PROXY_HOST, PROXY_PORT);
             }
-
+			Document doc = connection.get();
+			Elements ogTitleTags = doc.select("meta[property=og:title]");
+			Elements twitterTitleTags = doc.select("meta[name=twitter:title]");
+			if (!ogTitleTags.isEmpty()) {
+				return Objects.requireNonNull(ogTitleTags.first()).attr("content");
+			}else if(!twitterTitleTags.isEmpty()) {
+				return Objects.requireNonNull(twitterTitleTags.first()).attr("content");
+			}
             return connection.get().title();
         } catch(IOException e) {
             return href;


### PR DESCRIPTION
## 작업 내용
- jsoup의 메타데이터 중 Title을 가져오는 로직 변경했습니다.
- 카카오톡 링크 추출 시 해당 사이트의 제목을 가져올 수 있도록 추가했습니다.