### PR TITLE
카카오톡 링크 추출 API 수정

### DIFF
--- a/linknamu/src/main/java/com/kakao/linknamu/core/exception/GlobalExceptionHandler.java
+++ b/linknamu/src/main/java/com/kakao/linknamu/core/exception/GlobalExceptionHandler.java
@@ -74,7 +74,7 @@ public class GlobalExceptionHandler {
 
 		log.error(errorText);
 		return new ResponseEntity<>(
-			ApiUtils.error(String.format("internal server error  %s", errorText), HttpStatus.INTERNAL_SERVER_ERROR.value(), "05000"),
+			ApiUtils.error("internal server", HttpStatus.INTERNAL_SERVER_ERROR.value(), "05000"),
 			HttpStatus.INTERNAL_SERVER_ERROR
 		);
 	}

--- a/linknamu/src/main/java/com/kakao/linknamu/kakao/dto/KakaoSendMeResponseDto.java
+++ b/linknamu/src/main/java/com/kakao/linknamu/kakao/dto/KakaoSendMeResponseDto.java
@@ -2,7 +2,8 @@ package com.kakao.linknamu.kakao.dto;
 
 public record KakaoSendMeResponseDto(
 	String title,
-	String link
+	String link,
+	String imageUrl
 
 ) {
 

--- a/linknamu/src/main/java/com/kakao/linknamu/kakao/service/KaKaoSendMeExtractService.java
+++ b/linknamu/src/main/java/com/kakao/linknamu/kakao/service/KaKaoSendMeExtractService.java
@@ -4,6 +4,7 @@ import com.kakao.linknamu.core.exception.Exception400;
 import com.kakao.linknamu.core.exception.Exception500;
 import com.kakao.linknamu.kakao.KakaoExceptionStatus;
 import com.kakao.linknamu.kakao.dto.KakaoSendMeResponseDto;
+import com.kakao.linknamu.thirdparty.utils.JsoupResult;
 import com.kakao.linknamu.thirdparty.utils.JsoupUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,7 +24,6 @@ import java.util.regex.Pattern;
 public class KaKaoSendMeExtractService {
 
 	private final JsoupUtils jsoupUtils;
-	private static final String DEFAULT_TITLE = "추출된 링크";
 
 	public List<KakaoSendMeResponseDto> extractLink(MultipartFile multipartFile) {
 
@@ -61,10 +61,11 @@ public class KaKaoSendMeExtractService {
 					if (httpsLink.endsWith("\"")) {
 						httpsLink = httpsLink.substring(0, httpsLink.length() - 1);
 					}
-					String title = jsoupUtils.getTitle(httpsLink);
+					JsoupResult jsoupResult = jsoupUtils.getTitleAndImgUrl(httpsLink);
 					responseDtos.add(new KakaoSendMeResponseDto(
-						title.equals(httpsLink) ? DEFAULT_TITLE : title,
-						httpsLink)
+						jsoupResult.getTitle(),
+						httpsLink,
+						jsoupResult.getImageUrl())
 					);
 				});
 


### PR DESCRIPTION
## 작업내용
- 카카오톡 링크 추출 API 응답 데이터에 링크에 대한 이미지 주소를 추가했습니다.
- 예외 발생시 응답데이터에는 에러에 대한 상세한 내용이 나오지 않도록 설정했습니다.