### PR TITLE
Feat: Dto 검증, 북마크 링크 저장크기 확장, 북마크 이동 예외처리

### DIFF
--- a/linknamu/src/main/java/com/kakao/linknamu/bookmark/BookmarkExceptionStatus.java
+++ b/linknamu/src/main/java/com/kakao/linknamu/bookmark/BookmarkExceptionStatus.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum BookmarkExceptionStatus implements BaseExceptionStatus {
 	BOOKMARK_ALREADY_EXISTS("해당 북마크 링크가 이미 존재합니다.", 400, "24000"),
+	BOOKMARK_LINK_TOO_LONG("너무 긴 북마크 링크입니다.", 400, "24001"),
 	BOOKMARK_FORBIDDEN("북마크 접근 권한이 없는 사용자입니다.", 403, "24030"),
 	BOOKMARK_NOT_FOUND("대상 북마크가 존재하지 않습니다.", 404, "24040");
 

--- a/linknamu/src/main/java/com/kakao/linknamu/bookmark/controller/BookmarkController.java
+++ b/linknamu/src/main/java/com/kakao/linknamu/bookmark/controller/BookmarkController.java
@@ -74,7 +74,7 @@ public class BookmarkController {
 
 	@PostMapping("/search")
 	public ResponseEntity<?> searchBookmark(
-		@RequestBody BookmarkSearchCondition condition,
+		@RequestBody @Valid BookmarkSearchCondition condition,
 		@RequestParam(name = "page", defaultValue = "0") int page,
 		@AuthenticationPrincipal CustomUserDetails user) {
 		Pageable pageable = PageRequest.of(page, PAGE_SIZE);

--- a/linknamu/src/main/java/com/kakao/linknamu/bookmark/dto/BookmarkRequestDto.java
+++ b/linknamu/src/main/java/com/kakao/linknamu/bookmark/dto/BookmarkRequestDto.java
@@ -2,9 +2,7 @@ package com.kakao.linknamu.bookmark.dto;
 
 import com.kakao.linknamu.bookmark.entity.Bookmark;
 import com.kakao.linknamu.category.entity.Category;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -16,20 +14,24 @@ public class BookmarkRequestDto {
 	@Setter
 	public static class BookmarkAddDto {
 
-		@NotEmpty
+		@NotBlank(message = "북마크 이름은 공백이 될 수 없습니다.")
+		@Size(max = 100, message = "북마크 이름은 최대 100자까지 가능합니다.")
 		private String bookmarkName;
 
-		@NotEmpty
+		@NotBlank(message = "북마크 링크는 공백이 될 수 없습니다.")
 		@Pattern(regexp = "https?://[a-zA-Z0-9\\-.]+(:[0-9]+)?\\.[a-zA-Z]{2,3}(\\S*)?", message = "잘못된 웹 링크입니다.")
+		@Size(max = 1024, message = "너무 긴 링크입니다.")
 		private String bookmarkLink;
 
+		@Size(max = 200, message = "북마크 설명을 최대 200자까지 가능합니다.")
 		private String bookmarkDescription;
 
-		@NotNull
+		@NotNull(message = "카테고리 ID를 입력해주세요.")
 		private Long categoryId;
 
 		private String imageUrl;
 
+		@Size(max = 50, message = "태그는 최대 50자까지 가능합니다.")
 		private List<String> tags;
 
 		public Bookmark toEntity(Category category, String imageUrl) {

--- a/linknamu/src/main/java/com/kakao/linknamu/bookmark/dto/BookmarkSearchCondition.java
+++ b/linknamu/src/main/java/com/kakao/linknamu/bookmark/dto/BookmarkSearchCondition.java
@@ -2,9 +2,11 @@ package com.kakao.linknamu.bookmark.dto;
 
 import java.util.List;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
 public record BookmarkSearchCondition(
+	@NotBlank(message = "북마크 이름은 공백이 될 수 없습니다.")
 	String bookmarkName,
 	String bookmarkLink,
 	String bookmarkDescription,

--- a/linknamu/src/main/java/com/kakao/linknamu/bookmark/entity/Bookmark.java
+++ b/linknamu/src/main/java/com/kakao/linknamu/bookmark/entity/Bookmark.java
@@ -1,6 +1,8 @@
 package com.kakao.linknamu.bookmark.entity;
 
+import com.kakao.linknamu.bookmark.BookmarkExceptionStatus;
 import com.kakao.linknamu.category.entity.Category;
+import com.kakao.linknamu.core.exception.Exception400;
 import com.kakao.linknamu.core.util.AuditingEntity;
 import com.querydsl.core.annotations.QueryInit;
 import jakarta.persistence.*;
@@ -49,7 +51,7 @@ public class Bookmark extends AuditingEntity {
 	@Column(length = 200, name = "bookmark_description")
 	private String bookmarkDescription;
 
-	@Column(length = 512, name = "bookmark_thumbnail")
+	@Column(length = 1024, name = "bookmark_thumbnail")
 	private String bookmarkThumbnail;
 
 	public void moveCategory(Category category) {
@@ -62,9 +64,16 @@ public class Bookmark extends AuditingEntity {
 		this.bookmarkId = bookmarkId;
 		this.category = category;
 		this.bookmarkName = bookmarkName;
-		this.bookmarkLink = bookmarkLink;
+		this.bookmarkLink = getValidBookmarkLink(bookmarkLink);
 		this.bookmarkDescription = bookmarkDescription;
 		this.bookmarkThumbnail = bookmarkThumbnail;
+	}
+
+	private String getValidBookmarkLink(String bookmarkLink) {
+		if(bookmarkLink.length() > 1024) {
+			throw new Exception400(BookmarkExceptionStatus.BOOKMARK_LINK_TOO_LONG);
+		}
+		return bookmarkLink;
 	}
 
 	@Override

--- a/linknamu/src/main/java/com/kakao/linknamu/bookmark/service/BookmarkService.java
+++ b/linknamu/src/main/java/com/kakao/linknamu/bookmark/service/BookmarkService.java
@@ -178,7 +178,9 @@ public class BookmarkService {
 
 		for (Bookmark bookmark : requestedBookmarks) {
 			validUser(bookmark.getCategory(), user);
-			validDuplicatedLink(toCategory, bookmark.getBookmarkLink());
+			// 만약 같은 카테고리로 이동한다면 중복 검사를 할 필요가 없다.
+			if(!isMoveSameCategory(bookmark.getCategory(), toCategory))
+				validDuplicatedLink(toCategory, bookmark.getBookmarkLink());
 			examineSet.add(bookmark.getBookmarkId());
 		}
 
@@ -204,6 +206,11 @@ public class BookmarkService {
 			.equals(user.getUserId())) {
 			throw new Exception403(BookmarkExceptionStatus.BOOKMARK_FORBIDDEN);
 		}
+	}
+
+	// 이동하려는 북마크의 카테고리가 같은지 체크
+	private boolean isMoveSameCategory(Category fromCategory, Category toCategory) {
+		return fromCategory.getCategoryId().equals(toCategory.getCategoryId());
 	}
 
 	// 요청 북마크들이 모두 실제로 디비에 존재하는 북마크인지 체크

--- a/linknamu/src/main/java/com/kakao/linknamu/bookmarktag/dto/CreateBookmarkTagRequestDto.java
+++ b/linknamu/src/main/java/com/kakao/linknamu/bookmarktag/dto/CreateBookmarkTagRequestDto.java
@@ -1,6 +1,11 @@
 package com.kakao.linknamu.bookmarktag.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 public record CreateBookmarkTagRequestDto(
+	@NotBlank(message = "태그 이름은 공백이 될 수 없습니다.")
+	@Size(max = 50, message = "태그는 최대 50자까지 가능합니다.")
 	String tagName
 ) {
 }

--- a/linknamu/src/main/java/com/kakao/linknamu/bookmarktag/dto/DeleteBookmarkTagRequestDto.java
+++ b/linknamu/src/main/java/com/kakao/linknamu/bookmarktag/dto/DeleteBookmarkTagRequestDto.java
@@ -1,7 +1,11 @@
 package com.kakao.linknamu.bookmarktag.dto;
 
+import jakarta.validation.constraints.NotNull;
+
 public record DeleteBookmarkTagRequestDto(
+	@NotNull(message = "북마크 ID를 입력해주세요.")
 	Long bookmarkId,
+	@NotNull(message = "태그 ID를 입력해주세요.")
 	Long tagId
 ) {
 }

--- a/linknamu/src/main/java/com/kakao/linknamu/category/dto/CategorySaveRequestDto.java
+++ b/linknamu/src/main/java/com/kakao/linknamu/category/dto/CategorySaveRequestDto.java
@@ -1,9 +1,14 @@
 package com.kakao.linknamu.category.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record CategorySaveRequestDto(
-	@NotNull String categoryName,
-	@NotNull Long workspaceId
+	@NotBlank(message = "카테고리 이름은 공백이 될 수 없습니다.")
+	@Size(max = 100, message = "카테고리 이름은 최대 100자까지 가능합니다.")
+	String categoryName,
+	@NotNull(message = "워크스페이스 ID를 입력해주세요.")
+	Long workspaceId
 ) {
 }

--- a/linknamu/src/main/java/com/kakao/linknamu/category/dto/CategoryUpdateRequestDto.java
+++ b/linknamu/src/main/java/com/kakao/linknamu/category/dto/CategoryUpdateRequestDto.java
@@ -1,8 +1,10 @@
 package com.kakao.linknamu.category.dto;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record CategoryUpdateRequestDto(
-	@NotNull String categoryName
+	@NotBlank(message = "카테고리 이름은 공백이 될 수 없습니다.")
+	@Size(max = 100) String categoryName
 ) {
 }

--- a/linknamu/src/main/java/com/kakao/linknamu/thirdparty/googledocs/dto/RegisterGoogleDocsRequestDto.java
+++ b/linknamu/src/main/java/com/kakao/linknamu/thirdparty/googledocs/dto/RegisterGoogleDocsRequestDto.java
@@ -3,7 +3,7 @@ package com.kakao.linknamu.thirdparty.googledocs.dto;
 import jakarta.validation.constraints.NotBlank;
 
 public record RegisterGoogleDocsRequestDto(
-	@NotBlank
+	@NotBlank(message = "구글 문서의 ID는 공백이 될 수 없습니다.")
 	String documentId
 ) {
 }

--- a/linknamu/src/main/java/com/kakao/linknamu/thirdparty/notion/dto/RegisterNotionRequestDto.java
+++ b/linknamu/src/main/java/com/kakao/linknamu/thirdparty/notion/dto/RegisterNotionRequestDto.java
@@ -3,8 +3,10 @@ package com.kakao.linknamu.thirdparty.notion.dto;
 import jakarta.validation.constraints.NotBlank;
 
 public record RegisterNotionRequestDto(
-	@NotBlank String code,
-	@NotBlank String pageId
+	@NotBlank(message = "노션 코드는 공백이 될 수 없습니다.")
+	String code,
+	@NotBlank(message = "노션 페이지 ID는 공백이 될 수 없습니다.")
+	String pageId
 
 ) {
 }

--- a/linknamu/src/main/java/com/kakao/linknamu/user/dto/ReissueDto.java
+++ b/linknamu/src/main/java/com/kakao/linknamu/user/dto/ReissueDto.java
@@ -7,7 +7,8 @@ public class ReissueDto {
 
 
 	public record ReissueRequestDto(
-		@NotNull String refreshToken
+		@NotNull(message = "Refresh 토큰을 입력해주세요.")
+		String refreshToken
 	) {
 		@Builder
 		public ReissueRequestDto {


### PR DESCRIPTION
## 작업내용
- Dto 검증 추가
- 북마크 링크를 512자에서 1024자로 확장
- 북마크 이동 시 같은 카테고리로 이동한다면 정상 응답이 나오도록 변경